### PR TITLE
Fixes SSH connection loop when no image exists

### DIFF
--- a/lib/danarchy_sys/cli/instance_manager.rb
+++ b/lib/danarchy_sys/cli/instance_manager.rb
@@ -142,7 +142,7 @@ Should we create a new instance named #{instance_name}? (Y/N): "
           return instance
         else
           puts "Not creating new instance: #{instance_name}."
-          return
+          return false
         end
       end
     end

--- a/lib/danarchy_sys/cli/instance_manager/prompts_create_instance.rb
+++ b/lib/danarchy_sys/cli/instance_manager/prompts_create_instance.rb
@@ -89,7 +89,6 @@ class PromptsCreateInstance
 
     flavor_name = item_chooser(flavors_numbered, 'flavor')
     print "Flavor Name: #{flavor_name.split('.')[1]}\n"
-    p comp_flvs.methods
     comp_flvs.get_flavor_by_name(flavor_name)
   end
 

--- a/lib/danarchy_sys/version.rb
+++ b/lib/danarchy_sys/version.rb
@@ -1,3 +1,3 @@
 module DanarchySys
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
system(ssh) returns 'false' if a remote command errors, so this was causing fallback_ssh to loop instead of breaking back out to the menu. Also removes debugging output.