### PR TITLE
patch_0.5.2: Account/ConfigMgr and @os_compute connection cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
-gem 'fog-openstack'
+
+gemspec

--- a/danarchy_sys.gemspec
+++ b/danarchy_sys.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'danarchy_sys/version'
@@ -7,15 +7,13 @@ Gem::Specification.new do |spec|
   spec.name          = "danarchy_sys"
   spec.version       = DanarchySys::VERSION
   spec.authors       = ["Dan James"]
-  spec.email         = ["danheneise@me.com"]
+  spec.email         = ["dan@danarchy.me"]
 
   spec.summary       = %q{Facilitates the deployment and management of OpenStack.}
   spec.description   = %q{dAnarchy Sys is intended to be a platform for the management of cloud compute instances from initial setup through to the deployment of end-user software.}
   spec.homepage      = "https://github.com/danarchy85/danarchy_sys"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
@@ -30,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-openstack", "~> 0.1", ">=0.1.20"
+  spec.add_dependency "fog-openstack", "~> 0.1.20"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/danarchy_sys/cli.rb
+++ b/lib/danarchy_sys/cli.rb
@@ -1,6 +1,4 @@
 
-# require 'optparse'
-# require 'fog/openstack'
 require_relative '../danarchy_sys'
 
 module DanarchySys

--- a/lib/danarchy_sys/cli/accounts.rb
+++ b/lib/danarchy_sys/cli/accounts.rb
@@ -1,7 +1,6 @@
 
 class Accounts
-  def self.chooser
-    danarchysys_config = DanarchySys::ConfigManager::Config.new
+  def self.chooser(danarchysys_config)
     accounts = Helpers.array_to_numhash(danarchysys_config[:accounts].keys)
     account = 'nil'
 

--- a/lib/danarchy_sys/cli/instance_manager.rb
+++ b/lib/danarchy_sys/cli/instance_manager.rb
@@ -2,15 +2,18 @@ require_relative 'instance_manager/prompts_create_instance'
 require_relative 'instance_manager/instance_status'
 
 class InstanceManager
-  def self.manager(os_compute)
-    comp_inst = os_compute.instances
+  def self.manager(os_compute, settings)
+    @os_compute = os_compute
+    @settings   = settings
+    @prompts_create_instance = PromptsCreateInstance.new(@os_compute, @settings)
     puts 'Instance Manager: enter \'help\' to view available commands or \'main\' for the main menu.'
     menu = Menus.numbered_menu('instance')
     instance = false
 
     loop do
+      trap('SIGINT') { print "\nEnter an instance to manage or enter a name for a new instance: " }
       while instance == false
-        instance = chooser(os_compute)
+        instance = chooser
         return Menus.print_menu('main') if instance == 'main'
       end
 
@@ -29,20 +32,20 @@ class InstanceManager
       elsif cmd == 'main'
         return Menus.print_menu('main')
       elsif cmd == 'chooser'
-        instance = chooser(os_compute)
+        instance = chooser
       elsif cmd == 'create'
-        PromptsCreateInstance.create_instance(os_compute, 'nil')
-        instance = chooser(os_compute)
+        instance = @prompts_create_instance.create_instance(nil)
       elsif cmd == 'delete'
         print "Are you sure you wish to delete instance: #{instance.name}? (this is permanent!) (Y/N): "
-        delete = comp_inst.delete_instance(instance.name) if gets.chomp =~ /^y(es)?$/i
+        delete = @os_compute.instances.delete_instance(instance.name) if gets.chomp =~ /^y(es)?$/i
         if delete == true
           puts "#{instance.name} has been deleted! Returning to the instance chooser."
-          instance = chooser(os_compute)
+          instance = chooser
         else
           puts "#{instance.name} was not deleted!"
         end
       elsif cmd == 'status'
+        instance = @os_compute.instances.get_instance(instance.name)
         printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
       elsif %w(pause unpause suspend resume start stop).include?(cmd.to_s)
         status = instance.state
@@ -53,32 +56,33 @@ class InstanceManager
           print "#{cmd}ing #{instance.name} ."
         end
 
-        response = comp_inst.send(cmd.to_s, instance.name.to_s)
+        response = @os_compute.instances.send(cmd.to_s, instance.name.to_s)
         if response == false
           puts "\nInvalid action for #{instance.name}'s current status!"
           next
         end
 
         until status != instance.state
-          instance = os_compute.instances.get_instance(instance.name)
+          instance = @os_compute.instances.get_instance(instance.name)
           sleep(3)
           print ' .'
         end
 
         printf("\n%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
       elsif cmd == 'rebuild'
-        image = PromptsCreateInstance.image(os_compute.images)
+        image = @prompts_create_instance.image
         print "Should we rebuild #{instance.name} with image: #{image.name}? (Y/N): "
         if gets.chomp =~ /^y(es)?$/i
           puts "Rebuilding #{instance.name} with #{image.name}"
-          instance = os_compute.instances.rebuild_instance(instance, image)
-          puts "\nRebuild successful!"
+          @os_compute.instances.rebuild_instance(instance, image)
+          instance = @os_compute.instances.get_instance(instance.name)
+          puts "\nRebuild in progress!"
         else
           puts "Not rebuilding #{instance.name} at this time."
         end
       elsif cmd == 'connect'
         if instance.state == 'ACTIVE'
-          os_compute.ssh(instance.name)          
+          @os_compute.ssh(instance.name)          
         else
           puts "Unable to connect: #{instance.name} is not running!"
         end
@@ -91,8 +95,8 @@ class InstanceManager
     end
   end
 
-  def self.chooser(os_compute)
-    instances_numhash = Helpers.objects_to_numhash(os_compute.instances.all_instances)
+  def self.chooser
+    instances_numhash = Helpers.objects_to_numhash(@os_compute.instances.all_instances)
     instance_name = nil
     instance = nil
 
@@ -100,19 +104,19 @@ class InstanceManager
     if instances_numhash.empty?
       print 'No existing instances were found. Should we create a new one? (Y/N): '
       abort('Exiting!') unless gets.chomp =~ /^y(es)?$/i
-      instance = PromptsCreateInstance.create_instance(os_compute, 'nil')
+      instance = @prompts_create_instance.create_instance(nil)
       puts "Working with: #{instance.name}\tStatus: #{instance.state}"
       return instance
     end
 
     puts 'Available instances:'
-    istatus = InstanceStatus.new(os_compute)
+    istatus = InstanceStatus.new(@os_compute)
     istatus.all_instances(instances_numhash)
 
     # Loop input until an existing instance is selected
     print 'Enter an instance to manage or enter a name for a new instance: '
 
-    until instances_numhash.values.collect{|i| i[:name]}.include?(instance_name) # os_compute.instances.check_instance(instance_name) == true
+    until instances_numhash.values.collect{|i| i[:name]}.include?(instance_name)
       instance_name = gets.chomp
 
       until instance_name.empty? == false
@@ -133,12 +137,12 @@ class InstanceManager
         instance_name = instances_numhash[instance_name.to_i][:name].to_s
       end
 
-      unless instances_numhash.values.collect{|i| i[:name]}.include?(instance_name) # os_compute.instances.check_instance(instance_name) == true
+      unless instances_numhash.values.collect{|i| i[:name]}.include?(instance_name)
         print "#{instance_name} is not a valid instance.
 Should we create a new instance named #{instance_name}? (Y/N): "
 
         if gets.chomp =~ /^y(es)?$/i
-          instance = PromptsCreateInstance.create_instance(os_compute, instance_name)
+          instance = @prompts_create_instance.create_instance(instance_name)
           return instance
         else
           puts "Not creating new instance: #{instance_name}."
@@ -147,7 +151,7 @@ Should we create a new instance named #{instance_name}? (Y/N): "
       end
     end
 
-    instance = os_compute.instances.get_instance(instance_name)
+    instance = @os_compute.instances.get_instance(instance_name)
     Menus.print_menu('instance')
     puts "Managing instance: #{instance_name}\tStatus: #{instance.state}"
     instance

--- a/lib/danarchy_sys/config_manager.rb
+++ b/lib/danarchy_sys/config_manager.rb
@@ -1,13 +1,13 @@
+require_relative 'config_manager/openstack'
 require 'fileutils'
 require 'json'
-require_relative 'config_manager/openstack'
 
 # dAnarchy_sys config management
 module DanarchySys
   module ConfigManager
     class Config
       def self.new
-        danarchysys_cfg_path = File.join(File.realpath(ENV['HOME']), '.danarchy_sys')
+        danarchysys_cfg_path = File.join(File.realpath(ENV['HOME']), '.danarchy', 'danarchy_sys')
         config_json = File.join(danarchysys_cfg_path, 'danarchy_sys.json')
 
         if File.exists?(config_json)
@@ -19,7 +19,7 @@ module DanarchySys
       end
       
       def self.providers
-        ['openstack'] # , 'aws']
+        ['openstack', 'danarchy'] # , 'aws']
       end
 
       def self.config_template

--- a/lib/danarchy_sys/openstack/compute/instances.rb
+++ b/lib/danarchy_sys/openstack/compute/instances.rb
@@ -91,8 +91,8 @@ class ComputeInstances
     instance.stop
   end
 
-  def create_instance(instance_name, image_id, flavor_id, keypair_name, *user_data)
-    user_data = nil if user_data.empty?
+  def create_instance(instance_name, image_id, flavor_id, keypair_name, *userdata)
+    user_data = userdata ? userdata.first : nil
 
     instance = @compute.servers.create(name: instance_name,
                                       image_ref: image_id,
@@ -116,9 +116,9 @@ class ComputeInstances
     instance.rebuild(image.id, instance.name)
     addrs = [get_public_addresses(instance),
              get_private_addresses(instance)].flatten.compact!
-    addrs.each { |addr| system("ssh-keygen -R #{addr}") }
+    addrs.each { |addr| system("ssh-keygen -R #{addr} &>/dev/null") }
 
-    instance.wait_for { ready? }
+    # instance.wait_for { ready? }
     instance
   end
 
@@ -138,7 +138,7 @@ class ComputeInstances
 
     addrs = [get_public_addresses(instance),
              get_private_addresses(instance)].flatten.compact!
-    addrs.each { |addr| system("ssh-keygen -R #{addr}") }
+    addrs.each { |addr| system("ssh-keygen -R #{addr} &>/dev/null") }
 
     return true
   end

--- a/lib/danarchy_sys/version.rb
+++ b/lib/danarchy_sys/version.rb
@@ -1,3 +1,3 @@
 module DanarchySys
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
- UserData editing in CLI::InstanceManager::PromptsCreateInstance and implementation in OpenStack::Compute::Instance.
- Restructure calls to Account and Config Managers
- InstanceManager
  - Catch SIGINT and safely exit.
  - Call @os_compute directly instead of comp_inst/imgs/flvs...etc. This helps to ensure API data is fresh (current status checks, for example).