### PR TITLE
patch_0.5.4: Abort on Ctrl+d, fix fallback_ssh

### DIFF
--- a/lib/danarchy_sys/cli.rb
+++ b/lib/danarchy_sys/cli.rb
@@ -21,9 +21,9 @@ module DanarchySys
 
       loop do
         print 'command ~: '
-        cmd = gets.chomp
+        cmd = gets
+        cmd = cmd ? cmd.chomp : abort('Exiting!')
 
-        next if cmd.empty?
         if cmd =~ /^[0-9]*$/
           menu[cmd.to_i].map { |k, v| cmd = k } if menu.keys.include? cmd.to_i
         end

--- a/lib/danarchy_sys/cli/accounts.rb
+++ b/lib/danarchy_sys/cli/accounts.rb
@@ -17,9 +17,8 @@ class Accounts
 
     until accounts.values.include?(account)
       print 'Which account should we use? (enter \'exit\' to leave): '
-      account = gets.chomp
-
-      abort('Exiting') if account == 'exit'
+      account = gets
+      account = account ? account.chomp : abort('Exiting!')
 
       if account =~ /^[0-9]*$/
         account = accounts[account.to_i]

--- a/lib/danarchy_sys/cli/instance_manager.rb
+++ b/lib/danarchy_sys/cli/instance_manager.rb
@@ -18,9 +18,8 @@ class InstanceManager
       end
 
       print "#{instance.name} ~: " if instance
-      cmd = gets.chomp
-
-      next if cmd.empty?
+      cmd = gets
+      cmd = cmd ? cmd.chomp : abort('Exiting!')
       abort('Exiting!') if cmd == 'exit'
 
       if cmd =~ /^[0-9]*$/
@@ -46,7 +45,8 @@ class InstanceManager
         end
       elsif cmd == 'status'
         instance = @os_compute.instances.get_instance(instance.name)
-        if instance.state == 'ACTIVE' && @os_compute.ssh(instance, 'uptime')[:stderr]
+        uptime_result = @os_compute.ssh(instance, 'uptime')
+        if instance.state == 'ACTIVE' && uptime_result[:stderr]
           printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', 'WAITING')
         else
           printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
@@ -120,13 +120,14 @@ class InstanceManager
     print 'Enter an instance to manage or enter a name for a new instance: '
 
     until instances_numhash.values.collect{|i| i[:name]}.include?(instance_name)
-      instance_name = gets.chomp
+      instance_name = gets
 
       until instance_name.empty? == false
         print 'Input was blank! Enter an instance or Id from above: '
         instance_name = gets.chomp
       end
 
+      instance_name = instance_name ? instance_name.chomp : abort('Exiting!')
       abort('Exiting') if instance_name == 'exit'
       return 'main' if instance_name == 'main'
 

--- a/lib/danarchy_sys/version.rb
+++ b/lib/danarchy_sys/version.rb
@@ -1,3 +1,3 @@
 module DanarchySys
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end


### PR DESCRIPTION
- Allows for using Ctrl+d to exit at any prompts.
- Updates DanarchySys::OpenStack::Compute#fallback_ssh to work with new SSH class.
- Add 'gentoo' user for Gentoo based guests.