### PR TITLE
patch_0.6.1: fix instance status check once again

### DIFF
--- a/lib/danarchy_sys/cli/instance_manager.rb
+++ b/lib/danarchy_sys/cli/instance_manager.rb
@@ -45,14 +45,12 @@ class InstanceManager
         end
       elsif cmd == 'status'
         instance = @os_compute.instances.get_instance(instance.name)
-        if instance.state == 'ACTIVE'
-          uptime_result = @os_compute.ssh(instance, 'uptime')
-
-          if uptime_result[:stderr]
-            printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', 'WAITING')
-          else
-            printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
-          end
+        if instance.state != 'ACTIVE'
+          printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
+        elsif @os_compute.ssh(instance, 'uptime')[:stderr]
+          printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', 'WAITING')
+        else
+          printf("%#{instance.name.size}s %0s %0s\n", instance.name, ' => ', instance.state)
         end
       elsif %w(pause unpause suspend resume start stop).include?(cmd.to_s)
         status = instance.state

--- a/lib/danarchy_sys/version.rb
+++ b/lib/danarchy_sys/version.rb
@@ -1,3 +1,3 @@
 module DanarchySys
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
- instance_manager.rb is failing to check instance status if instance.state == 'ACTIVE'. Seemed to be a fault in the logic, so this is now a single if/elsif/else check now.